### PR TITLE
require at least 1 splitter

### DIFF
--- a/src/strpkg/call.nim
+++ b/src/strpkg/call.nim
@@ -132,6 +132,8 @@ proc call_main*() =
     if b.right - b.left > 1000'u32:
       stderr.write_line "large bounds:" & $b & " skipping"
       continue
+    # skip with only a single splitter
+    if b.n_left + b.n_right <= 1: continue
 
     var (spans, median_depth) = ibam.spanners(b, window, frag_dist, opts.min_mapq)
     var gt = genotype(b, c.reads, spans, targets, float(median_depth))

--- a/src/strpkg/extract.nim
+++ b/src/strpkg/extract.nim
@@ -17,6 +17,7 @@ import math
 import argparse
 
 proc get_repeat*(aln:Record, genome_str:TableRef[string, Lapper[region]], counts:var Seqs[uint8], repeat_count: var int, align_length: var int, opts:Options): array[6, char] =
+  repeat_count = 0
   when defined(skipFullMatch):
     # compile with -d:skipFullMatch to make it much faster
     if aln.cigar.len == 1 and aln.cigar[0].op == CigarOp.match:
@@ -220,6 +221,11 @@ proc add(cache:var Cache, aln:Record, genome_str:TableRef[string, Lapper[region]
 
     # If both reads in pair are STR, or one is STR, one low mapping qual, set position to unknown
     if unplaced_pair(self, mate, opts):
+      # we only keep unplaced pairs if both reads have some repeat unit
+      # we could require them to have the same repeat unit...
+      if self.repeat[0] == '\0' or mate.repeat[0] == '\0':
+        return
+
       # NOTE: we don't know if we need to reverse complement these reads
       # so we will have to equate forward and reverse repeat units later.
       self.position = uint32(0)

--- a/src/strpkg/utils.nim
+++ b/src/strpkg/utils.nim
@@ -211,6 +211,8 @@ proc get_repeat*(read: var string, counts: var Seqs[uint8], repeat_count: var in
       if read.count(s) > (read.len.float * opts.proportion_repeat / k.float).int:
         copyMem(result.addr, s[0].addr, k)
         repeat_count = count
+        if repeat_count > 0 and result[0] == '\0':
+          quit "bad:" & $k & " " & $result & " " & "kmer:" & s
     elif count < (read.len.float * 0.12 / k.float).int:
       # e.g. for a 5 mer repeat, we should see some 2, 3, 4 mer reps and we can
       # bail if we do not. this is an optimization to avoid counting when we
@@ -218,6 +220,8 @@ proc get_repeat*(read: var string, counts: var Seqs[uint8], repeat_count: var in
       break
 
   repeat_count *= reduce_repeat(result)
+
+
 
 proc tostring*(a:array[6, char]): string =
   for c in a:


### PR DESCRIPTION
for unplaced pairs, require that both have some repeat content