### PR TITLE
Address input bed file bugs

### DIFF
--- a/src/strpkg/cluster.nim
+++ b/src/strpkg/cluster.nim
@@ -116,6 +116,8 @@ proc parse_bedline*(l:string, targets: seq[Target], window: uint32): Bounds =
   result.left = uint32(parseInt(l_split[1]))
   result.right = uint32(parseInt(l_split[2]))
   result.repeat = l_split[3]
+  if result.repeat.len > 6:
+    quit &"ERROR: STRling currently only supports 1-6 bp repeat units. Input bed contains repeat unit length {result.repeat.len}\n{l}"
   # Ensure left_most and right_most are within the chromosome
   # (convert uint to int to allow negative numbers)
   result.left_most = uint32(max(int32(result.left) - int32(window), 0))

--- a/src/strpkg/merge.nim
+++ b/src/strpkg/merge.nim
@@ -91,7 +91,7 @@ proc merge_main*() =
 
 
   var opts = Options(median_fragment_length: frag_dist.median(0.98),
-                      min_support: min_support, min_mapq: min_mapq)
+                      min_support: min_support, min_mapq: min_mapq, targets: targets)
 
   if window < 0:
     window = frag_dist.median(0.98)


### PR DESCRIPTION
Addresses #58
Also checks input bed file for repeat units lengths > 6 and exits with useful error message.