### PR TITLE
WIP: reduce memory use

### DIFF
--- a/docs/source/run.rst
+++ b/docs/source/run.rst
@@ -5,6 +5,14 @@ Run
    :maxdepth: 2
    :caption: Contents:
 
+Creating a genome STR index (optional)
+--------------------------------------
+
+Creates a bed file of large STR regions in the reference genome. This step is peformed automatically as part of `strling extract`. However, when running multiple samples, it is more efficient to do it once, then pass the file to `strling extract` using the `-g` option.
+
+.. code-block:: bash
+
+    strling index $reference_fasta
 
 Single sample
 -------------

--- a/pipelines/pipeline-stages.groovy
+++ b/pipelines/pipeline-stages.groovy
@@ -9,7 +9,18 @@ def get_fname(path) {
     def x = path.split("/")[-1]
     return(x)
 }
- 
+
+str_index = {
+    def str_ref = get_fname(REF) + ".str"
+    produce(str_ref) {
+        exec """
+            $STRLING index
+                $REF
+                -g $str_ref
+        ""","strling"
+    }
+}
+
 str_extract = {
     def sample = branch.name
     def str_ref = get_fname(REF) + ".str"

--- a/pipelines/strling-individual.groovy
+++ b/pipelines/strling-individual.groovy
@@ -5,5 +5,6 @@
 load 'pipeline-stages.groovy'
 
 run {
+    str_index +
     "%.${input_type}" * [str_extract + str_call_individual]
 }

--- a/pipelines/strling-joint.groovy
+++ b/pipelines/strling-joint.groovy
@@ -5,7 +5,8 @@
 load 'pipeline-stages.groovy'
 
 run {
+    str_index +
     "%.${input_type}" * [str_extract] +
-        str_merge +
+    str_merge +
     "%.bin" * [str_call_joint] //+ str_outlier
 }

--- a/src/strling.nim
+++ b/src/strling.nim
@@ -7,6 +7,7 @@ import ./strpkg/merge
 import ./strpkg/call
 import ./strpkg/version
 import ./strpkg/extract_region
+import ./strpkg/genome_strs
 
 proc main*() =
 
@@ -18,6 +19,7 @@ proc main*() =
     "extract": pair(f:extract_main, description:"extract informative STR reads from a BAM/CRAM. This is a required first step."),
     "merge": pair(f:merge_main, description:"merge putitive STR loci from multiple samples. Only required for joint calling."),
     "call": pair(f:call_main, description:"call STRs"),
+    "index": pair(f:index_main, description:"identify large STRs in the reference genome, to produce ref.fasta.str."),
     "pull_region": pair(f:extract_region_main, description:"for debugging; pull all reads (and mates) for a given regions"),
     }.toOrderedTable
   var args = commandLineParams()

--- a/src/strpkg/cluster.nim
+++ b/src/strpkg/cluster.nim
@@ -348,6 +348,19 @@ iterator trcluster*(reps: seq[tread], max_dist:uint32, min_supporting_reads:int)
     for sc in c.split_cluster(min_supporting_reads):
       yield sc
 
+type tread_id = object
+  tr: tread
+  id: uint32
+
+proc has_per_sample_reads(c:Cluster, supporting_reads:int, qname2sample:TableRef[string, uint32]): bool =
+  ## check that, within the cluster there are at least `supporting reads` from
+  ## 1 sample.
+  var sample_counts = initCountTable[uint32](8)
+  for r in c.reads:
+    sample_counts.inc(qname2sample[r.qname])
+
+  return sample_counts.largest().val >= supporting_reads
+
 iterator cluster*(reps: var seq[tread], max_dist:uint32, min_supporting_reads:int=5): Cluster =
   # reps passed here are guaranteed to be split by tid and repeat unit.
   if reps.len > 0:
@@ -360,3 +373,17 @@ iterator cluster*(reps: var seq[tread], max_dist:uint32, min_supporting_reads:in
       for c in trcluster(reps, max_dist, min_supporting_reads):
         yield c
 
+iterator cluster*(id_reps: var seq[tread_id], max_dist:uint32, supporting_reads:int=5): Cluster =
+  # reps passed here are guaranteed to be split by tid and repeat unit.
+  # need a lookup from qname -> sample and to extract the qreads from each sample.
+  var qname2sample = newTable[string, uint32]()
+  var reps = newSeqOfCap[tread](id_reps.len)
+  for r in id_reps:
+    qname2sample[r.tr.qname] = r.id
+    reps.add(r.tr)
+
+  # then call normal cluster iterator
+  for c in reps.cluster(max_dist, supporting_reads):
+    # then check if this cluster has enough reads from 1 sample.
+      if c.has_per_sample_reads(supporting_reads, qname2sample):
+        yield c

--- a/src/strpkg/cluster.nim
+++ b/src/strpkg/cluster.nim
@@ -348,9 +348,9 @@ iterator trcluster*(reps: seq[tread], max_dist:uint32, min_supporting_reads:int)
     for sc in c.split_cluster(min_supporting_reads):
       yield sc
 
-type tread_id = object
-  tr: tread
-  id: uint32
+type tread_id* = object
+  tr*: tread
+  id*: uint32
 
 proc has_per_sample_reads(c:Cluster, supporting_reads:int, qname2sample:TableRef[string, uint32]): bool =
   ## check that, within the cluster there are at least `supporting reads` from

--- a/src/strpkg/genome_strs.nim
+++ b/src/strpkg/genome_strs.nim
@@ -167,15 +167,15 @@ proc check_reference_size*(b:Bounds, fai:Fai, chrom: string): int =
 
   result = reference[0..<min(right, reference.len)].count(b.repeat)
 
-proc genome_main*() =
+proc index_main*() =
 
-  var p = newParser("str genome-sites"):
-    option("-p", "--proportion-repeat", help="proportion of read that is repetitive to be considered as STR", default="0.65")
+  var p = newParser("str index"):
+    option("-g", "--genome-repeats", help="optional path to output genome repeats file. if it does not exist, it will be created (default: ./<FASTA>.str)")
+    option("-p", "--proportion-repeat", help="proportion of read that is repetitive to be considered as STR", default="0.8")
     arg("fasta", help="path to fasta file")
-    arg("bed", help="path to output bed file to be created")
 
   var argv = commandLineParams()
-  if len(argv) > 0 and argv[0] == "genome-sites":
+  if len(argv) > 0 and argv[0] == "index":
     argv = argv[1..argv.high]
   if len(argv) == 0: argv = @["--help"]
 
@@ -183,12 +183,18 @@ proc genome_main*() =
   if args.help:
     quit 0
 
+  var genome_repeats = args.genome_repeats
+  if genome_repeats == "":
+    genome_repeats = lastPathPart(args.fasta) & ".str"
+
   var fai:Fai
   if not fai.open(args.fasta):
     quit &"[strling] couldn't open fasta {args.fasta} make sure file is present and has a .fai index"
 
+  stderr.write_line &"Writing genome str index to: {genome_repeats}"
+
   var opts = Options(proportion_repeat: parseFloat(args.proportion_repeat))
-  discard fai.genome_repeats(opts, args.bed)
+  discard fai.genome_repeats(opts, genome_repeats)
 
 when isMainModule:
 
@@ -201,6 +207,6 @@ when isMainModule:
       echo w.trim(dna)
   ]#
 
-  genome_main()
+  index_main()
 
 

--- a/src/strpkg/unpack.nim
+++ b/src/strpkg/unpack.nim
@@ -78,9 +78,10 @@ proc unpack_file*(fs:FileStream, expected_format_version:int16=0): tuple[targets
   var n_reads:int32
   fs.read(n_reads)
   stderr.write_line &"[strling] reading {n_reads} STR reads from bin file"
+  result.reads = newSeqOfCap[tread](nreads)
 
   while not fs.atEnd:
-    var t:tread
+    var t = tread()
     fs.unpack_type(t)
     result.reads.add(t)
 


### PR DESCRIPTION
other options to reduce memory use is in merge are:

+ use a seq sorted by tid, repeat. currently, we partition in a Table by tid, repeat, then sort by position, but we could sort by tid, then repeat, then position in 1 huge seq and then send the correct portion of that seq to `cluster`.

+ we could process unplaced reads separately. 70% of reads are unplaced and these don't help in merge for clustering. Need input from @hdashnow  on how to handle this. This is like the best avenue as it could reduce memory footprint by an additional 70%.