### PR TITLE
fixing typo

### DIFF
--- a/src/strpkg/extract.nim
+++ b/src/strpkg/extract.nim
@@ -318,7 +318,7 @@ proc extract_main*() =
 
     cache.add(aln, genome_str, counts, opts)
 
-  stderr.write_line "[strling] extracting unampped reads"
+  stderr.write_line "[strling] extracting unmapped reads"
   # get unmapped reads
   for aln in ibam.query("*"):
     if aln.flag.secondary or aln.flag.supplementary: continue


### PR DESCRIPTION
I assume the 'unampped' should be 'unmapped'