### PR TITLE
Ignore inconsistent soft-clips

### DIFF
--- a/src/strpkg/call.nim
+++ b/src/strpkg/call.nim
@@ -229,7 +229,8 @@ proc call_main*() =
 
       var b: Bounds
       var good_cluster: bool
-      (b, good_cluster) = bounds(c, min_clip, min_clip_total)
+      let max_clip_dist: uint16 = uint16(0.5 * frag_dist.median(0.5).float)
+      (b, good_cluster) = bounds(c, min_clip, min_clip_total, max_clip_dist)
       if good_cluster == false:
         continue
 

--- a/src/strpkg/callclusters.nim
+++ b/src/strpkg/callclusters.nim
@@ -49,11 +49,11 @@ proc assign_reads_locus*(locus: var Bounds, treads_by_tid_rep: TableRef[tid_rep,
       elif r.split == Soft.left:
         locus.n_left.inc
 
-proc bounds*(c: Cluster, min_clip: uint16, min_clip_total: uint16): (Bounds, bool) =
+proc bounds*(c: Cluster, min_clip: uint16, min_clip_total: uint16, max_clip_dist:uint16): (Bounds, bool) =
   if c.reads.len >= uint16.high.int:
     stderr.write_line "More than " & &"{uint16.high.int}" & " reads in cluster with first read:" & $c.reads[0] & " skipping"
     return
-  var b = c.bounds
+  var b = c.bounds(max_clip_dist)
   if b.right - b.left > 1000'u32:
     stderr.write_line "large bounds:" & $b & " skipping"
     return

--- a/src/strpkg/merge.nim
+++ b/src/strpkg/merge.nim
@@ -165,7 +165,8 @@ proc merge_main*() =
 
       var b: Bounds
       var good_cluster: bool
-      (b, good_cluster) = bounds(c, min_clip, min_clip_total)
+      let max_clip_dist: uint16 = uint16(0.5 * frag_dist.median(0.5).float)
+      (b, good_cluster) = bounds(c, min_clip, min_clip_total, max_clip_dist)
       if good_cluster == false:
         continue
 

--- a/tests/test_cluster.nim
+++ b/tests/test_cluster.nim
@@ -117,6 +117,26 @@ suite "cluster suite":
     check b.left == 3
     check b.right == 4
 
+  test "test bounds: filter out soft-clips that are inconsistent with the center mass":
+    var reads = @[
+      tread(tid:1'i32, repeat: ['A', 'T', 'G', '\x00', '\x00', '\x00'], position: 100, split: Soft.right),
+      tread(tid:1'i32, repeat: ['A', 'T', 'G', '\x00', '\x00', '\x00'], position: 123, split: Soft.none),
+      tread(tid:1'i32, repeat: ['A', 'T', 'G', '\x00', '\x00', '\x00'], position: 223, split: Soft.none),
+      tread(tid:1'i32, repeat: ['A', 'T', 'G', '\x00', '\x00', '\x00'], position: 223, split: Soft.none),
+      tread(tid:1'i32, repeat: ['A', 'T', 'G', '\x00', '\x00', '\x00'], position: 223, split: Soft.none),
+      tread(tid:1'i32, repeat: ['A', 'T', 'G', '\x00', '\x00', '\x00'], position: 253, split: Soft.none),
+      tread(tid:1'i32, repeat: ['A', 'T', 'G', '\x00', '\x00', '\x00'], position: 283, split: Soft.none),
+      ]
+
+    let max_clip_dist:uint16 = 50
+    var cl = Cluster(reads:reads)
+    var b = cl.bounds(max_clip_dist)
+    check b.left == 223
+    check b.right == 224
+    check b.left_most == 100
+    check b.right_most == 283
+    check b.center_mass == 223
+
 # This test is failing. Need to think about how to fix
 #  test "test bounds: no left soft-clipped reads so use median":
 #    var reads = @[


### PR DESCRIPTION
When determining the bounds for a locus, ignore soft-clips that are inconsistent with the center mass.
Ignore left soft-clips that are too far to the right, and right soft-clips that are too far to the left of the center mass.
"Too far" is half the median fragment size.

Possible addition: re-calculate the center mass and far left and right bounds after removing those soft clips?
