### PR TITLE
report 0-len alignments in debug mode. 

### DIFF
--- a/src/strpkg/extract.nim
+++ b/src/strpkg/extract.nim
@@ -68,7 +68,7 @@ proc to_tread(aln:Record, genome_str:TableRef[string, Lapper[region]], counts: v
   doAssert align_length >= 0, aln.tostring
   when defined(debug):
     if align_length == 0:
-      stderr.write_line &"0-length alignment: {aln.tostring}"
+      stderr.write_line &"0-length alignment: {aln.qname} {aln.tostring}"
   doAssert repeat_count < 256, aln.tostring
 
   result = tread(tid:aln.tid.int32,

--- a/src/strpkg/extract.nim
+++ b/src/strpkg/extract.nim
@@ -64,7 +64,11 @@ proc to_tread(aln:Record, genome_str:TableRef[string, Lapper[region]], counts: v
   var repeat_count: int
   var align_length: int
   var rep = aln.get_repeat(genome_str, counts, repeat_count, align_length, opts)
+  # Allowing 0-len alignments has the potential to increase memory usage if they are frequent. Report for future debugging
   doAssert align_length >= 0, aln.tostring
+  when defined(debug):
+    if align_length == 0:
+      stderr.write_line &"0-length alignment: {aln.tostring}"
   doAssert repeat_count < 256, aln.tostring
 
   result = tread(tid:aln.tid.int32,


### PR DESCRIPTION
Could be useful in debugging memory issues later.
