### PR TITLE
add empty line for code block rendering on github

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -19,6 +19,7 @@ Install with conda
 We suggest conda installation if you want to perform outlier analysis, which requires a python script.
 
 .. code-block:: bash
+
   conda config --add channels bioconda
   conda install -y strling
 


### PR DESCRIPTION
Not sure if you really care about this, but the conda installation code block wasn't showing up on GitHub or the [documentation website](https://strling.readthedocs.io/en/latest/install.html#install-with-conda). Looks like a new empty line has solved this issue. 